### PR TITLE
add get meetup/conf api

### DIFF
--- a/devs-who-run-api/MembersEndpoint.cs
+++ b/devs-who-run-api/MembersEndpoint.cs
@@ -1,0 +1,71 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace devs_who_run_api;
+
+public static class MembersEndpoint
+{
+    public static async Task<IResult> GetPartnerMeetup(DevsWhoRunDbContext db)
+    {
+        try
+        {
+            var meetups = await db.Members.Where(m => m.UserType == UserType.Meetup).ToListAsync();
+
+            if (!meetups.Any())
+            {
+                return Results.NotFound(new { Message = "No partner meetup found." });
+            }
+
+            return Results.Ok(meetups);
+        }
+        catch (Exception e)
+        {
+            return Results.Problem(e.Message, statusCode: 500);
+        }
+    }
+
+    public static async Task<IResult> GetPartnerConferences(DevsWhoRunDbContext db)
+    {
+        try
+        {
+            var conferences = await db.Members.Where(m => m.UserType == UserType.Conf).ToListAsync();
+
+            if (!conferences.Any())
+            {
+                return Results.NotFound(new { Message = "No partner conferences found." });
+            }
+
+            return Results.Ok(conferences);
+        }
+        catch (Exception e)
+        {
+            return Results.Problem(e.Message, statusCode: 500);
+        }
+    }
+
+    public static async Task<IResult> AddMembers(Member member, DevsWhoRunDbContext db)
+    {
+
+        if (member == null)
+            return Results.BadRequest("Member data is required");
+
+        if (string.IsNullOrEmpty(member.Email))
+            return Results.BadRequest("Email is required");
+
+        try
+        {
+            member.CreatedOn = DateTime.UtcNow;
+            member.UpdatedOn = DateTime.UtcNow;
+
+            db.Members.Add(member);
+            await db.SaveChangesAsync();
+
+            return Results.Created($"/member/{member.Id}", member);
+        }
+        catch (Exception ex)
+        {
+            return Results.Problem(ex.Message, statusCode: 500);
+        }
+    }
+
+    
+}

--- a/devs-who-run-api/Program.cs
+++ b/devs-who-run-api/Program.cs
@@ -24,68 +24,11 @@ if (app.Environment.IsDevelopment())
 
 app.UseHttpsRedirection();
 
-app.MapGet("/getPartnerConference", async (DevsWhoRunDbContext db) =>
-{
-    try
-    {
-        var conferences = await db.Members.Where(m => m.UserType == UserType.Conf).ToListAsync();
+app.MapGet("/getPartnerConference", MembersEndpoint.GetPartnerConferences);
 
-        if (!conferences.Any())
-        {
-            return Results.NotFound(new { Message = "No partner conferences found." });
-        }
+app.MapGet("/getPartnerMeetup", MembersEndpoint.GetPartnerMeetup);
 
-        return Results.Ok(conferences);
-    }
-    catch (Exception e)
-    {
-        return Results.Problem(e.Message, statusCode: 500);
-    }
-
-});
-
-app.MapGet("/getPartnerMeetup", async (DevsWhoRunDbContext db) =>
-{
-    try
-    {
-        var meetups = await db.Members.Where(m => m.UserType == UserType.Meetup).ToListAsync();
-
-        if (!meetups.Any())
-        {
-            return Results.NotFound(new { Message = "No partner meetup found." });
-        }
-
-        return Results.Ok(meetups);
-    }
-    catch (Exception e)
-    {
-        return Results.Problem(e.Message, statusCode: 500);
-    }
-});
-
-app.MapPost("/addMember", async (Member member, DevsWhoRunDbContext db) =>
-{
-    if (member == null)
-        return Results.BadRequest("Member data is required");
-
-    if (string.IsNullOrEmpty(member.Email))
-        return Results.BadRequest("Email is required");
-
-    try
-    {
-        member.CreatedOn = DateTime.UtcNow;
-        member.UpdatedOn = DateTime.UtcNow;
-
-        db.Members.Add(member);
-        await db.SaveChangesAsync();
-
-        return Results.Created($"/member/{member.Id}", member);
-    }
-    catch (Exception ex)
-    {
-        return Results.Problem(ex.Message, statusCode: 500);
-    }
-});
+app.MapPost("/addMember", MembersEndpoint.AddMembers);
 
 app.MapGet("/getMemberByEmail/{email}", async (string email, DevsWhoRunDbContext db) =>
     await db.Members.FirstOrDefaultAsync(m => m.Email == email)

--- a/devs-who-run-api/Program.cs
+++ b/devs-who-run-api/Program.cs
@@ -28,7 +28,29 @@ var partnerConference = new[] { "TIL Conf" }
 ;
 
 
-app.MapGet("/getPartnerConference", () => partnerConference).WithName("GetPartnerConferences").WithOpenApi();
+app.MapGet("/getPartnerConference", async (DevsWhoRunDbContext db) =>
+{
+    var conferences = db.Members.Where(m => m.UserType == UserType.Conf).ToListAsync();
+
+    if (!conferences.Any())
+    {
+        return Results.NotFound(new { Message = "No partner conferences found." });
+    }
+
+    return Results.Ok(conferences);
+});
+
+app.MapGet("/getPartnerMeetup", async (DevsWhoRunDbContext db) =>
+{
+    var meetups = db.Members.Where(m => m.UserType == UserType.Meetup).ToListAsync();
+
+    if (!meetups.Any())
+    {
+        return Results.NotFound(new { Message = "No partner meetup found." });
+    }
+
+    return Results.Ok(meetups);
+});
 
 app.MapPost("/addMember", async (Member member, DevsWhoRunDbContext db) =>
 {

--- a/devs-who-run-api/Program.cs
+++ b/devs-who-run-api/Program.cs
@@ -30,7 +30,7 @@ var partnerConference = new[] { "TIL Conf" }
 
 app.MapGet("/getPartnerConference", async (DevsWhoRunDbContext db) =>
 {
-    var conferences = db.Members.Where(m => m.UserType == UserType.Conf).ToListAsync();
+    var conferences = await db.Members.Where(m => m.UserType == UserType.Conf).ToListAsync();
 
     if (!conferences.Any())
     {
@@ -42,7 +42,7 @@ app.MapGet("/getPartnerConference", async (DevsWhoRunDbContext db) =>
 
 app.MapGet("/getPartnerMeetup", async (DevsWhoRunDbContext db) =>
 {
-    var meetups = db.Members.Where(m => m.UserType == UserType.Meetup).ToListAsync();
+    var meetups = await db.Members.Where(m => m.UserType == UserType.Meetup).ToListAsync();
 
     if (!meetups.Any())
     {

--- a/devs-who-run-api/Program.cs
+++ b/devs-who-run-api/Program.cs
@@ -24,32 +24,43 @@ if (app.Environment.IsDevelopment())
 
 app.UseHttpsRedirection();
 
-var partnerConference = new[] { "TIL Conf" }
-;
-
-
 app.MapGet("/getPartnerConference", async (DevsWhoRunDbContext db) =>
 {
-    var conferences = await db.Members.Where(m => m.UserType == UserType.Conf).ToListAsync();
-
-    if (!conferences.Any())
+    try
     {
-        return Results.NotFound(new { Message = "No partner conferences found." });
+        var conferences = await db.Members.Where(m => m.UserType == UserType.Conf).ToListAsync();
+
+        if (!conferences.Any())
+        {
+            return Results.NotFound(new { Message = "No partner conferences found." });
+        }
+
+        return Results.Ok(conferences);
+    }
+    catch (Exception e)
+    {
+        return Results.Problem(e.Message, statusCode: 500);
     }
 
-    return Results.Ok(conferences);
 });
 
 app.MapGet("/getPartnerMeetup", async (DevsWhoRunDbContext db) =>
 {
-    var meetups = await db.Members.Where(m => m.UserType == UserType.Meetup).ToListAsync();
-
-    if (!meetups.Any())
+    try
     {
-        return Results.NotFound(new { Message = "No partner meetup found." });
-    }
+        var meetups = await db.Members.Where(m => m.UserType == UserType.Meetup).ToListAsync();
 
-    return Results.Ok(meetups);
+        if (!meetups.Any())
+        {
+            return Results.NotFound(new { Message = "No partner meetup found." });
+        }
+
+        return Results.Ok(meetups);
+    }
+    catch (Exception e)
+    {
+        return Results.Problem(e.Message, statusCode: 500);
+    }
 });
 
 app.MapPost("/addMember", async (Member member, DevsWhoRunDbContext db) =>
@@ -72,7 +83,7 @@ app.MapPost("/addMember", async (Member member, DevsWhoRunDbContext db) =>
     }
     catch (Exception ex)
     {
-        return Results.Problem("Failed to add member", statusCode: 500);
+        return Results.Problem(ex.Message, statusCode: 500);
     }
 });
 


### PR DESCRIPTION
This pull request introduces new endpoints and improves the existing endpoint in the `devs-who-run-api` project. The changes involve enhancing the functionality of the `/getPartnerConference` endpoint and adding a new `/getPartnerMeetup` endpoint.

### Enhancements to existing endpoint:
* Modified the `/getPartnerConference` endpoint to query the database for members with `UserType.Conf`, returning a `NotFound` result if no conferences are found.

### Addition of new endpoint:
* Added a new `/getPartnerMeetup` endpoint to query the database for members with `UserType.Meetup`, returning a `NotFound` result if no meetups are found.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new asynchronous endpoint `/getPartnerConference` for retrieving partner conferences.
	- Added a new endpoint `/getPartnerMeetup` for fetching partner meetups.
- **Improvements**
	- Enhanced error handling for the `/addMember` endpoint, providing clearer responses for errors.
	- Transitioned from static to dynamic data retrieval, improving real-time data access based on user types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->