### PR TITLE
feat: added api for discord total & online member count

### DIFF
--- a/src/DevsWhoRun.Api/Configurations/AppSettings.cs
+++ b/src/DevsWhoRun.Api/Configurations/AppSettings.cs
@@ -8,6 +8,7 @@ public class AppSettings
     public SwaggerSettings Swagger { get; set; } = new();
     public JwtSettings Jwt { get; set; } = new();
     public GitHubSettings GitHub { get; set; } = new();
+    public DiscordSettings Discord { get; set; } = new();
 }
 
 public class DatabaseSettings
@@ -31,6 +32,12 @@ public class JwtSettings
     public string Audience { get; set; } = string.Empty;
 }
 
+public class DiscordSettings
+{
+    public string BotToken { get; set; } = string.Empty;
+    public string ServerId { get; set; } = string.Empty;
+}
+
 public class GitHubSettings
 {
     public string ClientId { get; set; } = string.Empty;
@@ -42,7 +49,7 @@ public class GitHubSettings
     public string Scope { get; set; } = "user:email";
     // should changes to prod url latest this is for local
     public string RedirectUri { get; set; } = "http://localhost:5299/api/auth/github-callback";
-    
+
     public Dictionary<string, string> ClaimMappings { get; set; } = new()
     {
         { ClaimTypes.NameIdentifier, "id" },

--- a/src/DevsWhoRun.Api/Modules/Discord/DTOs/DiscordMembers.cs
+++ b/src/DevsWhoRun.Api/Modules/Discord/DTOs/DiscordMembers.cs
@@ -1,0 +1,3 @@
+namespace DevsWhoRun.Api.Modules.Discord.DTOs;
+
+public record DiscordMembers(int TotalMembers, int OnlineMembers);

--- a/src/DevsWhoRun.Api/Modules/Discord/DiscordModule.cs
+++ b/src/DevsWhoRun.Api/Modules/Discord/DiscordModule.cs
@@ -1,0 +1,28 @@
+using Carter;
+using DevsWhoRun.Api.Modules.Discord.Services.Interfaces;
+
+namespace DevsWhoRun.Api.Modules.Discord;
+
+public class DiscordModule : CarterModule
+{
+    public DiscordModule() : base("/api")
+    {
+        WithTags("Discord");
+        IncludeInOpenApi();
+    }
+    public override void AddRoutes(IEndpointRouteBuilder app)
+    {
+        app.MapGet("/discord/members", async (IDiscordService discordService) =>
+        {
+            try
+            {
+                var counts = await discordService.GetMembersCountAsync();
+                return Results.Ok(counts);
+            }
+            catch (Exception e)
+            {
+                return Results.Problem(e.Message, statusCode: 500);
+            }
+        });
+    }
+}

--- a/src/DevsWhoRun.Api/Modules/Discord/Services/DiscordService.cs
+++ b/src/DevsWhoRun.Api/Modules/Discord/Services/DiscordService.cs
@@ -1,0 +1,36 @@
+using System.Net.Http.Headers;
+using System.Text.Json;
+using DevsWhoRun.Api.Configurations;
+using DevsWhoRun.Api.Modules.Discord.DTOs;
+using DevsWhoRun.Api.Modules.Discord.Services.Interfaces;
+
+namespace DevsWhoRun.Api.Modules.Discord.Services;
+
+public class DiscordService(HttpClient httpClient, AppSettings appSettings) : IDiscordService
+{
+    private const string BaseUrl = "https://discord.com/api/v10";
+    public async Task<DiscordMembers> GetMembersCountAsync()
+    {
+        try
+        {
+            httpClient.DefaultRequestHeaders.Authorization =
+                new AuthenticationHeaderValue("Bot", appSettings.Discord.BotToken);
+            var response = await httpClient.GetAsync($"{BaseUrl}/guilds/{appSettings.Discord.ServerId}?with_counts=true");
+            response.EnsureSuccessStatusCode();
+            
+            var jsonString = await response.Content.ReadAsStringAsync();
+            using var document = JsonDocument.Parse(jsonString);
+            
+            var totalMembers = document.RootElement.GetProperty("approximate_member_count").GetInt32();
+            var onlineMembers = document.RootElement.GetProperty("approximate_presence_count").GetInt32();
+            return new DiscordMembers(totalMembers, onlineMembers);
+        }
+        catch (Exception e)
+        {
+            // Console.WriteLine(e);
+            // throw;
+            // added a fallback to return 0 members if the request fails will be removed in future as end to end setup
+            return new DiscordMembers(0, 0);
+        }
+    }
+}

--- a/src/DevsWhoRun.Api/Modules/Discord/Services/Interfaces/IDiscordService.cs
+++ b/src/DevsWhoRun.Api/Modules/Discord/Services/Interfaces/IDiscordService.cs
@@ -1,0 +1,8 @@
+using DevsWhoRun.Api.Modules.Discord.DTOs;
+
+namespace DevsWhoRun.Api.Modules.Discord.Services.Interfaces;
+
+public interface IDiscordService
+{
+    Task<DiscordMembers> GetMembersCountAsync();
+}

--- a/src/DevsWhoRun.Api/Program.cs
+++ b/src/DevsWhoRun.Api/Program.cs
@@ -7,6 +7,8 @@ using Microsoft.IdentityModel.Tokens;
 using System.Text;
 using DevsWhoRun.Api.Modules.Auth.Services;
 using DevsWhoRun.Api.Modules.Auth.Services.Interfaces;
+using DevsWhoRun.Api.Modules.Discord.Services;
+using DevsWhoRun.Api.Modules.Discord.Services.Interfaces;
 using Microsoft.AspNetCore.Authentication;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -69,6 +71,7 @@ builder.Services.AddDbContext<DevsWhoRunDbContext>(options =>
 // Register services
 builder.Services.AddHttpClient();
 builder.Services.AddScoped<IAuthService, AuthService>();
+builder.Services.AddScoped<IDiscordService, DiscordService>();
 
 builder.Services.AddCarter();
 builder.Services.AddAuthorization();

--- a/src/DevsWhoRun.Api/appsettings.json
+++ b/src/DevsWhoRun.Api/appsettings.json
@@ -29,5 +29,9 @@
     "UserInformationEndpoint": "https://api.github.com/user",
     "Scope": "user:email",
     "RedirectUri": "http://localhost:5299/api/auth/github-callback"
+  },
+  "Discord": {
+    "BotToken": "replace with the bot token",
+    "ServerId": "replace with the server id"
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added Discord integration to retrieve server member counts
	- Introduced a new endpoint `/api/discord/members` to fetch Discord server statistics

- **Configuration**
	- Added Discord-specific settings in application configuration
	- Implemented service to interact with Discord API for member information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->